### PR TITLE
Readme.md

### DIFF
--- a/readme.html
+++ b/readme.html
@@ -37,15 +37,15 @@ div.fixedFooter { border-top: 1px solid black; position: fixed; font-size: 0.9em
 <div class="fixHeading">
 	<h1>[h] Dice Manager</h1>
 	<ul class="topmenu">
-		<li><a href="#info">Informationen</a></li>
+		<li><a href="#info">Information</a></li>
 		<li><a href="#inst">Installation</a></li>
-		<li><a href="#options">Einstellungen</a></li>
-		<li><a href="#usergroup">Benutzergruppen</a></li>
-		<li><a href="#dice">Würfel</a></li>
-		<li><a href="#rules">Regeln</a></li>
-		<li><a href="#wiresets">Systeme</a></li>
-		<li><a href="#forum">Foren</a></li>
-		<li><a href="#usage">Benutzung</a></li>
+		<li><a href="#options">Settings</a></li>
+		<li><a href="#usergroup">Usergroups</a></li>
+		<li><a href="#dice">Dice</a></li>
+		<li><a href="#rules">Rules</a></li>
+		<li><a href="#wiresets">Wireframes</a></li>
+		<li><a href="#forum">Forum</a></li>
+		<li><a href="#usage">Usage</a></li>
 		<li><a href="#style">Styling</a></li>
 		<li><a href="#credits">Credits</a></li>
 	</u>

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,114 @@
+# [h] Dice Manager
+
+*   [Information](#info)
+*   [Installation](#inst)
+*   [Settings](#options)
+*   [Usergroups](#usergroup)
+*   [Dice](#dice)
+*   [Rules](#rules)
+*   [Wireframes](#wiresets)
+*   [Forum](#forum)
+*   [Usage](#usage)
+*   [Styling](#style)
+*   [Credits](#credits)
+
+<div id="info"></div>
+## Information
+
+This Dice Manager from Hoffi is an awesome Tool, which is used to roll Dice.
+
+In the AdminCP the Admin can add and edit dice, rules and wiresets (RPG Systems like D&D) with easy and complex rules. All can be ex- and imported.
+
+You can do much more, than roll a simmple d10 inside a post. You can roll your attack roll with your skill and the system will tell you, it your roll was a success.
+
+Inside your post the rolls are displayed and can be collapsed to save space.
+
+I developed this addon very integrated into the XenForo System, so you can use Alerts, Moderation log, Admin Search, statistics and more.
+
+Please give me Feedback at XenDACH.de or XenForo.com
+
+<div id="inst"></div>
+## Installation
+
+It's really easy. Simple du this few steps:
+
+1.  Upload all files from the upload directory to the corresponding directory on your server.
+2.  Install the XML AddOn File.
+3.  After that follow the next steps in this instructions for your first Setup.
+
+<div id="options"></div>
+## Settings
+
+The Basic Settings are some few self explaining settings.
+
+At the Bottom is a field for a system Key. If you save the settings with activated "fetch key" option, the system will contact my server and send back a key. Only the URL, the AddOn and the AddOn Version will be transferred to my server.
+
+The key is only an information for me, the addon will ever work without a license key with all options. If you don't want to fetch a key, so don't so it and enjoy the AddOn without.
+
+If you get e key once, at every update the new Version will be promoted to my. But I have only the actual Information. I store no history or any personal data.
+
+<div id="usergroup"></div>
+## Usergroups
+
+There are three new rights for usergroups:
+
+*   Can roll dice
+*   Can see rolled dice
+*   can delte every dice roll (moderative rights)
+
+There is no right, that a user can delete own rolls, to prevent misbehaviour.
+
+<div id="rules"></div>
+## Dice
+
+First, you mus create dice. In theimport folder you can import a pre-Set of dice. You must use all three import files from one language to get the system to work.
+
+You can edit every attribute of the die after the import, but not the tag like d6.
+
+If you want to change the icon of an image, upload your own. You can use individual Images per Style.
+
+<div id="dice"></div>
+## Rules
+
+Import the rules from the same language as the dice. You can add your own rules.
+
+The rules define, if a roll is won or not.
+
+<div id="wiresets"></div>
+## Wireframes
+
+After you imported dice and rules, you can import the wireframes in the same language. Wireframes are the Dice System, like World of Darkness or Dungeons and Dragons.
+
+Just take a look at the wireframes, create your own and share them. There is an export function.
+
+## Forums
+
+Now its time, to tell your fourms, to acced dice rolls. Edit the Node and you see a new tab with additions informations for the dice settings.
+
+If you have installed many wireframes, you can select individual wireframes that can be rolled per forum.
+
+<div id="usage"></div>
+## Usage
+
+Phew. Now you can roll in your posts. This wa a lot of work, but your users will thank you!
+
+If you activated the new style propertiy to show rollabe icon in the node list, you can select a forum in which can rolled.
+
+Just create a thread, or add a reply and click on the new button that appears on the bottom of the editor if you enabled this type of posting. The a dialog appears and you can set the roll options. Hit roll.   
+Hint: Only the active tab can rolled.
+
+Moderators can delete rolls, if you activated this. They can add an alert for the users.
+
+<div id="style"></div>
+## Styling
+
+There are new style settings for the dice manager. So you can indidualize the look and feel of all dice and icons.
+
+<div id="credits"></div>
+## Credits
+
+The 6sided die Icon is from http://www.icon-king.com/.
+
+The dice backgrounds are my little work. I added the source file. Feel free to modify them to your wish.
+
+© 2015 by Hoffi


### PR DESCRIPTION
Improve the English of Readme.html, and add a Readme.md.

The readme.md is the preferred format on github for displaying things like readme files.

I used https://domchristie.github.io/to-markdown/ to convert html to markdown, but it required a little editing.